### PR TITLE
Improved community page layout, fixes #4

### DIFF
--- a/ttn_org/ttn/static/ttn/css/community.css
+++ b/ttn_org/ttn/static/ttn/css/community.css
@@ -113,7 +113,7 @@ h1 {
 }
 
 .frontpage-small {
-    height: 12em;
+    min-height: 12em;
     width: 100%;
     background-repeat: no-repeat;
     background-size: cover;
@@ -124,13 +124,30 @@ h1 {
     float: left;
 }
 
+.header-content {
+    display: block;
+    max-width: 70%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .logo {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 2em;
     width: 8em;
+    height: 8em;
     background-color: white;
     border-radius: 50%;
-    position: absolute;
-    top: 2em;
-    left: 2em;
+}
+
+.header-author {
+    display: block;
+    margin-top: 2em;
+    margin-bottom: 2em;
+    text-align: center;
+    font-size: 2em;
 }
 
 .inititator {
@@ -145,15 +162,7 @@ h1 {
 }
 
 .initiator-name {
-    margin: auto;
-    position: absolute;
-    top: 14em;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    height: 1em;
-    text-align: center;
-    font-size: 2em;
+   margin: 0px;
 }
 
 .initiator-city {

--- a/ttn_org/ttn/templates/ttn/community/base_small.html
+++ b/ttn_org/ttn/templates/ttn/community/base_small.html
@@ -3,10 +3,14 @@
 
 {% block header %}
             <div class="frontpage-small" style="background-image: url('{% if community.image_url %}{{ community.image_url }}{% else %}{% static 'ttn/media/examplecity-newyork.jpg' %}{% endif %}');">
-                <a href="{% url 'ttn:index' %}">
-                    <img class="logo" src="{% static 'ttn/media/The Things Uitlijning.svg' %}">
-                </a>
-                {% block author %}
-                {% endblock %}
+                <div class="header-content row">
+                    <a href="{% url 'ttn:index' %}">
+                        <img class="logo col-md-9" src="{% static 'ttn/media/The Things Uitlijning.svg' %}">
+                    </a>
+                    <div class="header-author col-md-9">
+                        {% block author %}
+                        {% endblock %}
+                    </div>
+                </div>
             </div>
 {% endblock %}


### PR DESCRIPTION
The community page should now features a nice and responsive header with the content of the author block in the right place:

<img width="803" alt="screen shot 2015-10-27 at 17 00 53" src="https://cloud.githubusercontent.com/assets/1408377/10764158/25ce95b8-7ccd-11e5-809c-2c8edfaec976.png">
<img width="1440" alt="screen shot 2015-10-27 at 17 01 06" src="https://cloud.githubusercontent.com/assets/1408377/10764159/25d3cc86-7ccd-11e5-9cd1-ea78e5a102a8.png">

It could break the `community/index.html` page however. Make sure to check this before deploying.