### PR TITLE
Remove overlapping element

### DIFF
--- a/ttn_org/ttn/templates/ttn/community/start-a-community.html
+++ b/ttn_org/ttn/templates/ttn/community/start-a-community.html
@@ -1,11 +1,6 @@
 {% extends "ttn/community/base_small.html" %}
 {% load staticfiles %}
 
-{% block author %}
-    <h2 class="initiator-name">Start your own The Things Network community</h2>
-{% endblock %}
-
-
 {% block content %}
 
         <article class="intro">


### PR DESCRIPTION
There was a leftover title that was overlapping other content in the "Start a community" page.

Before:
![image](https://cloud.githubusercontent.com/assets/933277/11018459/185e0462-85ca-11e5-9ffc-4fda462a948a.png)

After:
![image](https://cloud.githubusercontent.com/assets/933277/11018460/20406bca-85ca-11e5-845e-4caf7efea7aa.png)
